### PR TITLE
Moved Parse local server to cloud server

### DIFF
--- a/GoTripApplication/src/app/app.component.ts
+++ b/GoTripApplication/src/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit {
   };
 
   ngOnInit(){
-    
+
   
   }
 }

--- a/GoTripApplication/src/app/app.component.ts
+++ b/GoTripApplication/src/app/app.component.ts
@@ -17,8 +17,7 @@ export class AppComponent implements OnInit {
   };
 
   ngOnInit(){
-
-
+    
   
   }
 }

--- a/GoTripApplication/src/environments/environment.ts
+++ b/GoTripApplication/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false,
   serverId: 'GoTripAppID',
   serverMasterKey: '==HyUH78YT$5%33==*&99',
-  serverUrl: 'http://127.0.0.1:1337/api',
+  serverUrl: 'https://gotrip-app.herokuapp.com/api',
 
 };
 

--- a/ParseServer/index.js
+++ b/ParseServer/index.js
@@ -9,7 +9,7 @@ const test = args.some(arg => arg.includes('jasmine'));
 const SimpleSendGridAdapter = require('parse-server-sendgrid-adapter');
 
 //const databaseUri = process.env.DATABASE_URI || process.env.MONGODB_URI;
-const databaseUri = `mongodb+srv://goTripMongoAtlas:wf5vAe7sz7gfbrXh@cluster0.t1uau.mongodb.net/goTrip?retryWrites=true&w=majority`
+const databaseUri = process.env.MONGODB_URI;
 
 var options = { allowInsecureHTTP: false };
 
@@ -21,15 +21,15 @@ const config = {
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
   appId: process.env.APP_ID || 'GoTripAppID',
   masterKey: process.env.MASTER_KEY || '==HyUH78YT$5%33==*&99', 
-  serverURL: process.env.SERVER_URL || 'http://localhost:1337/api', // Don't forget to change to https if needed
+  serverURL: process.env.SERVER_URL || 'https://gotrip-app.herokuapp.com/api', // Don't forget to change to https if needed
   liveQuery: {
     classNames: ['Posts', 'Comments'], // List of classes to support for query subscriptions
   },
-  publicServerURL: 'https://goTrip.lucasdacosta.com/parse', // change by the Heroku url to make it able confirm and reset the email and password
+  publicServerURL: 'https://gotrip-app.herokuapp.com/api', // change by the Heroku url to make it able confirm and reset the email and password
   verifyUserEmails: true,
   appName: 'GoTrip',
   emailAdapter: SimpleSendGridAdapter({
-    apiKey: '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',
+    apiKey: process.env.SENDGRID,
     fromAddress: 'gotrip.helpcenter@gmail.com',
   })
 };
@@ -40,7 +40,7 @@ const app = express();
 var dashboard = new ParseDashboard({
   "apps": [
     {
-      "serverURL": "http://localhost:1337/api",
+      "serverURL": "https://gotrip-app.herokuapp.com/api",
       "appId": "GoTripAppID",
       "masterKey": "==HyUH78YT$5%33==*&99",
       "appName": "GoTrip",

--- a/ParseServer/index.js
+++ b/ParseServer/index.js
@@ -47,7 +47,15 @@ var dashboard = new ParseDashboard({
       "iconName": "goTrip-logo.png",
     }
   ], 
-  "iconsFolder": "icons"
+  "iconsFolder": "icons",
+  "users": 
+  [
+    {
+        "user":"goTrip",
+        "pass":"goTrip123",
+        "apps": [{"appId": "GoTripAppID"}]
+    }
+  ]
 }, options);
 
 // Serve static assets from the /public folder

--- a/ParseServer/index.js
+++ b/ParseServer/index.js
@@ -11,7 +11,7 @@ const SimpleSendGridAdapter = require('parse-server-sendgrid-adapter');
 //const databaseUri = process.env.DATABASE_URI || process.env.MONGODB_URI;
 const databaseUri = process.env.MONGODB_URI;
 
-var options = { allowInsecureHTTP: false };
+var options = { allowInsecureHTTP: true };
 
 if (!databaseUri) {
   console.log('DATABASE_URI not specified, falling back to localhost.');
@@ -66,12 +66,6 @@ if (!test) {
 // Parse Server plays nicely with the rest of your web routes
 app.get('/', function (req, res) {
   res.status(200).send('I dream of being a website.  Please star the parse-server repo on GitHub!');
-});
-
-// There will be a test page available on the /test path of your server url
-// Remove this before launching your app
-app.get('/test', function (req, res) {
-  res.sendFile(path.join(__dirname, '/public/test.html'));
 });
 
 const port = process.env.PORT || 1337;

--- a/ParseServer/index.js
+++ b/ParseServer/index.js
@@ -26,7 +26,7 @@ const config = {
     classNames: ['Posts', 'Comments'], // List of classes to support for query subscriptions
   },
   publicServerURL: 'https://gotrip-app.herokuapp.com/api', // change by the Heroku url to make it able confirm and reset the email and password
-  verifyUserEmails: true,
+  //verifyUserEmails: true,
   appName: 'GoTrip',
   emailAdapter: SimpleSendGridAdapter({
     apiKey: process.env.SENDGRID,

--- a/ParseServer/index.js
+++ b/ParseServer/index.js
@@ -30,7 +30,7 @@ const config = {
   appName: 'GoTrip',
   emailAdapter: SimpleSendGridAdapter({
     apiKey: process.env.SENDGRID,
-    fromAddress: 'gotrip.helpcenter@gmail.com',
+    fromAddress: 'info@go-trip.tech',
   })
 };
 

--- a/ParseServer/package.json
+++ b/ParseServer/package.json
@@ -26,7 +26,8 @@
     "watch": "babel-watch index.js"
   },
   "engines": {
-    "node": ">=4.3"
+    "node": "14.9.0",
+    "npm": "6.14.8"
   },
   "devDependencies": {
     "babel-eslint": "10.1.0",


### PR DESCRIPTION
I moved the Parse Server to Heroku in order to protect the MongoAtlas' secret key and Sendgrid's secret key. They were exposed to everybody because Github's projects are public. 

The advantage is that now there is no need to start the Parse server, only the GoTrip application via CLI. The Parse server is online in the Cloud and available all the time (at least I hope it keeps working- let's see how it behaves in the next weeks). 

This change was also required in order to make the restore password work. I guess it will also be required to send invitation emails to the friends who are added to the trip plan, though not sure how that will work yet.