### PR TITLE
Choose Sights on Detail page

### DIFF
--- a/GoTripApplication/package.json
+++ b/GoTripApplication/package.json
@@ -9,7 +9,6 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
-    
   },
   "private": true,
   "dependencies": {

--- a/GoTripApplication/src/app/app.module.ts
+++ b/GoTripApplication/src/app/app.module.ts
@@ -53,7 +53,7 @@ const appRoutes: Routes = [
     {path: 'sights', component: AllSightsComponent},
     {path: 'map', component: MapComponent},
     {path: 'notes', component: NotesComponent},
-    {path: 'place/:xid', component: SightDetailComponent},
+    {path: 'place', component: SightDetailComponent},
 
   ] }
 ];

--- a/GoTripApplication/src/app/app.module.ts
+++ b/GoTripApplication/src/app/app.module.ts
@@ -53,7 +53,7 @@ const appRoutes: Routes = [
     {path: 'sights', component: AllSightsComponent},
     {path: 'map', component: MapComponent},
     {path: 'notes', component: NotesComponent},
-    {path: 'place', component: SightDetailComponent},
+    {path: 'place/:xid', component: SightDetailComponent},
 
   ] }
 ];

--- a/GoTripApplication/src/app/breadcrumb/breadcrumb.component.ts
+++ b/GoTripApplication/src/app/breadcrumb/breadcrumb.component.ts
@@ -14,15 +14,19 @@ export class BreadcrumbComponent implements OnInit {
   constructor(private router: Router, private route: ActivatedRoute, private createNewTrip: createNewTrip ) { }
 
   ngOnInit(): void {
-    
+    console.log(this.origin)
   }
   /*
   * Function to sen dthe user to teh previous page. It uses the origin variable to
   * decide to whenre they shoudl go back.
   */
   goBack(){
-    if(this.origin == 'newTripForm' || this.origin == 'tripDetails') this.createNewTrip.cleanInvitationList(); // Clean the email list
-    this.router.navigate(['../dashboard'])
+    if(this.origin == 'newTripForm' || this.origin == 'tripDetails'){
+      this.createNewTrip.cleanInvitationList(); // Clean the email list
+      this.router.navigate(['../dashboard'])
+    } else if (this.origin == 'moreInfo'){
+      // If came from moreInfo - page with details about the sight
+      this.router.navigate(['../../sights'], {relativeTo: this.route})
+    }
   }
-
 }

--- a/GoTripApplication/src/app/breadcrumb/breadcrumb.component.ts
+++ b/GoTripApplication/src/app/breadcrumb/breadcrumb.component.ts
@@ -26,7 +26,7 @@ export class BreadcrumbComponent implements OnInit {
       this.router.navigate(['../dashboard'])
     } else if (this.origin == 'moreInfo'){
       // If came from moreInfo - page with details about the sight
-      this.router.navigate(['../../sights'], {relativeTo: this.route})
+      this.router.navigate(['../sights'], {relativeTo: this.route})
     }
   }
 }

--- a/GoTripApplication/src/app/services/add-sight.service.ts
+++ b/GoTripApplication/src/app/services/add-sight.service.ts
@@ -4,7 +4,9 @@
 */
 
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 import * as Parse from 'parse';
+
 import { getTripDetails } from  './getTripDetails.service';
 import { currentUser } from './getCurrentUserData.service';
 
@@ -12,6 +14,8 @@ import { currentUser } from './getCurrentUserData.service';
   providedIn: 'root'
 })
 export class AddSightService {
+
+  updateUISightVoted = new Subject();
 
   constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
 
@@ -28,7 +32,7 @@ export class AddSightService {
     */
     await sight.save().then((res:any)=>{
       console.log('movedo to true')
-     
+      this.updateUISightVoted.next(); // Update the UI
     }, (err:any)=>{
       console.log(err)
     })
@@ -48,7 +52,7 @@ export class AddSightService {
       */
       await sight.save().then((res:any)=>{
         console.log('movedo to false')
-        
+        this.updateUISightVoted.next(); // Update the UI
       }, (err:any)=>{
         console.log(err)
       })

--- a/GoTripApplication/src/app/services/add-sight.service.ts
+++ b/GoTripApplication/src/app/services/add-sight.service.ts
@@ -16,7 +16,7 @@ export class AddSightService {
   constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
 
   async addSight(place:any){
-    console.log(place)
+    
     let Sight = Parse.Object.extend('Sight');
     let sight = new Sight();
     sight.id = place.sightServerId;
@@ -28,11 +28,57 @@ export class AddSightService {
     */
     await sight.save().then((res:any)=>{
       console.log('movedo to true')
-      //this.updateUISightVoted.next(); // Update the UI
+     
     }, (err:any)=>{
       console.log(err)
     })
   
-  }
+    }
+
+    async removeSight(place:any){
+    
+      let Sight = Parse.Object.extend('Sight');
+      let sight = new Sight();
+      sight.id = place.sightServerId;
+  
+      sight.set('addedToTrip', false)
+      
+      /*
+      * Save the update in Parse
+      */
+      await sight.save().then((res:any)=>{
+        console.log('movedo to false')
+        
+      }, (err:any)=>{
+        console.log(err)
+      })
+    
+      }
+
+      async getSightsAdded(){
+        let listSightsAdded = [];
+
+        let Sight = Parse.Object.extend('Sight');
+        let sightAdded = new Parse.Query(Sight);
+
+        let TripPlan = Parse.Object.extend('TripsPlan');
+        let tripPlan = new TripPlan();
+        tripPlan.id = this.getTripDetails.currentTrip.id;
+
+        sightAdded.equalTo('tripsPlanId', tripPlan) // find all sights that have this tripId
+        let result = await sightAdded.find();
+
+        // Get the list of sights added to the final trip
+
+        for(let i=0; i < result.length; i++){
+          let XID = result[i].get('XID');
+          let wasAddedToTrip = result[i].get('addedToTrip');
+          
+          wasAddedToTrip = wasAddedToTrip == true ? true : false; //If return undefined it turn false
+          
+          listSightsAdded.push({XID: XID, wasAddedToTrip: wasAddedToTrip});
+        }
+        return listSightsAdded // Return a array witht eh XID and total votes
+      }
 
 }

--- a/GoTripApplication/src/app/services/add-sight.service.ts
+++ b/GoTripApplication/src/app/services/add-sight.service.ts
@@ -1,0 +1,38 @@
+/*
+* Here is the code activated when the trip owner clicks on the add button located
+* on the cards sight. It will go to the sight class and turn addedToTrip into true
+*/
+
+import { Injectable } from '@angular/core';
+import * as Parse from 'parse';
+import { getTripDetails } from  './getTripDetails.service';
+import { currentUser } from './getCurrentUserData.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AddSightService {
+
+  constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
+
+  async addSight(place:any){
+    console.log(place)
+    let Sight = Parse.Object.extend('Sight');
+    let sight = new Sight();
+    sight.id = place.sightServerId;
+
+    sight.set('addedToTrip', true)
+    
+    /*
+    * Save the update in Parse
+    */
+    await sight.save().then((res:any)=>{
+      console.log('movedo to true')
+      //this.updateUISightVoted.next(); // Update the UI
+    }, (err:any)=>{
+      console.log(err)
+    })
+  
+  }
+
+}

--- a/GoTripApplication/src/app/services/getSights.service.ts
+++ b/GoTripApplication/src/app/services/getSights.service.ts
@@ -1,6 +1,8 @@
 export class getSights {
-    apiKey: string = ''
-    city: string = ''
+    apiKey: string = '';
+    
+    
+
 
 
 }

--- a/GoTripApplication/src/app/services/getTripDetails.service.ts
+++ b/GoTripApplication/src/app/services/getTripDetails.service.ts
@@ -17,6 +17,7 @@ export class getTripDetails {
     }
 
     currentTrip = {
+        id: '',
         status:{
             isTheOwner: false,
             hasAcceptedInvitation: true,
@@ -54,6 +55,10 @@ export class getTripDetails {
         tripPlan.id = id;
         queryTripPlan.equalTo("objectId", tripPlan.id); // Find the trip plan that has the informed ID
 
+        /*
+        * Save ID
+        */
+        this.currentTrip.id = id;    
         try{
             /*
             * Get information about city and trip title

--- a/GoTripApplication/src/app/services/more-info.service.ts
+++ b/GoTripApplication/src/app/services/more-info.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MoreInfoService {
+
+  constructor() { }
+
+  knowInfoAboutThisSight = {
+    xid:'',
+    name: '',
+    urlImage: '',
+    description: '',
+    geoPoints: {
+        lon: 0,
+        lat: 0
+    },
+  }
+
+    /*
+    * Save the sight selected in the details page in order to show in the page that shows more
+    * information about the place.
+    */
+    moreInfoAboutSight(selectedSignht: any){
+        this.knowInfoAboutThisSight.xid = selectedSignht.xid,
+        this.knowInfoAboutThisSight.name = selectedSignht.name,
+        this.knowInfoAboutThisSight.urlImage = selectedSignht.urlImage,
+        this.knowInfoAboutThisSight.description = selectedSignht.description,
+        this.knowInfoAboutThisSight.geoPoints.lon = selectedSignht.geoPoints.lon,
+        this.knowInfoAboutThisSight.geoPoints.lat = selectedSignht.geoPoints.lat
+    }
+
+    /*
+    * Clean the knowInfoAboutThisSight once the user leave the detils page
+    */
+    cleanMoreInfoAboutSight(){
+        this.knowInfoAboutThisSight.xid = '',
+        this.knowInfoAboutThisSight.name = '',
+        this.knowInfoAboutThisSight.urlImage = '',
+        this.knowInfoAboutThisSight.description = '',
+        this.knowInfoAboutThisSight.geoPoints.lon = 0,
+        this.knowInfoAboutThisSight.geoPoints.lat = 0
+    }
+}

--- a/GoTripApplication/src/app/services/more-info.service.ts
+++ b/GoTripApplication/src/app/services/more-info.service.ts
@@ -9,6 +9,7 @@ export class MoreInfoService {
 
   knowInfoAboutThisSight = {
     xid:'',
+    sightServerId: '',
     name: '',
     urlImage: '',
     description: '',
@@ -17,7 +18,8 @@ export class MoreInfoService {
         lat: 0
     },
     hasAcceptedInvitation: false,
-    isTheOwner: false
+    isTheOwner: false,
+    userVoted: false
   }
 
     /*
@@ -33,6 +35,8 @@ export class MoreInfoService {
         this.knowInfoAboutThisSight.geoPoints.lat = selectedSignht.geoPoints.lat
         this.knowInfoAboutThisSight.hasAcceptedInvitation = selectedSignht.hasAcceptedInvitation
         this.knowInfoAboutThisSight.isTheOwner = selectedSignht.isTheOwner
+        this.knowInfoAboutThisSight.userVoted = selectedSignht.userVoted
+        this.knowInfoAboutThisSight.sightServerId = selectedSignht.sightServerId
     }
 
     /*
@@ -46,6 +50,8 @@ export class MoreInfoService {
         this.knowInfoAboutThisSight.geoPoints.lon = 0,
         this.knowInfoAboutThisSight.geoPoints.lat = 0,
         this.knowInfoAboutThisSight.hasAcceptedInvitation = false,
-        this.knowInfoAboutThisSight.isTheOwner = false
+        this.knowInfoAboutThisSight.isTheOwner = false,
+        this.knowInfoAboutThisSight.userVoted = false,
+        this.knowInfoAboutThisSight.sightServerId = ''
     }
 }

--- a/GoTripApplication/src/app/services/more-info.service.ts
+++ b/GoTripApplication/src/app/services/more-info.service.ts
@@ -16,6 +16,8 @@ export class MoreInfoService {
         lon: 0,
         lat: 0
     },
+    hasAcceptedInvitation: false,
+    isTheOwner: false
   }
 
     /*
@@ -29,6 +31,8 @@ export class MoreInfoService {
         this.knowInfoAboutThisSight.description = selectedSignht.description,
         this.knowInfoAboutThisSight.geoPoints.lon = selectedSignht.geoPoints.lon,
         this.knowInfoAboutThisSight.geoPoints.lat = selectedSignht.geoPoints.lat
+        this.knowInfoAboutThisSight.hasAcceptedInvitation = selectedSignht.hasAcceptedInvitation
+        this.knowInfoAboutThisSight.isTheOwner = selectedSignht.isTheOwner
     }
 
     /*
@@ -40,6 +44,8 @@ export class MoreInfoService {
         this.knowInfoAboutThisSight.urlImage = '',
         this.knowInfoAboutThisSight.description = '',
         this.knowInfoAboutThisSight.geoPoints.lon = 0,
-        this.knowInfoAboutThisSight.geoPoints.lat = 0
+        this.knowInfoAboutThisSight.geoPoints.lat = 0,
+        this.knowInfoAboutThisSight.hasAcceptedInvitation = false,
+        this.knowInfoAboutThisSight.isTheOwner = false
     }
 }

--- a/GoTripApplication/src/app/services/vote.service.ts
+++ b/GoTripApplication/src/app/services/vote.service.ts
@@ -56,7 +56,8 @@ export class VoteService {
   * Fucntion to remove the vote from the current user
   */
    async removeVote(place: any){
-    console.log('removing==>' +place.sightServerId)
+    console.log('removing==>' +place)
+    console.log(place)
     let Sight = Parse.Object.extend('Sight');
     let sight = new Sight();
     sight.id = place.sightServerId;
@@ -68,16 +69,22 @@ export class VoteService {
     sight.decrement('totalVotes'); // Add +1 to the totalVotes
 
     /* If there is only the vote from this user the sight should be completely removed */
-
-    
-    /*
-    * Save the update in Parse
-    */
-    await sight.save().then((res:any)=>{
-      this.updateUISightVoted.next(); // Update the UI
-    }, (err:any)=>{
-      console.log(err)
-    })
+    if(place.totalVote <= 1) {
+      sight.destroy().then((resp:any)=>{
+        this.updateUISightVoted.next(); // Update the UI
+      }, (err:any)=>{
+        console.log(err)
+      })
+    } else {
+         /*
+          * Save the update in Parse
+          */
+          await sight.save().then((res:any)=>{
+            this.updateUISightVoted.next(); // Update the UI
+          }, (err:any)=>{
+            console.log(err)
+          })
+    } 
   }
 
 

--- a/GoTripApplication/src/app/services/vote.service.ts
+++ b/GoTripApplication/src/app/services/vote.service.ts
@@ -11,6 +11,9 @@ export class VoteService {
 
   constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
 
+  /*
+  * Fucntion to save the sight the user like in Parse
+  */
   addVote(place: any){
     
     let Sight = Parse.Object.extend('Sight');
@@ -41,5 +44,35 @@ export class VoteService {
     }, (err:any)=>{
       console.log(err)
     })
+  }
+
+  /*
+  * Function to get the sigts id the logged user liked
+  */
+  async getUserVotes(){
+    let userVotes:any = [];
+
+    const user = new Parse.User(); // Create a user object with the loged user
+    user.id = this.currentUser.userId;
+
+    // Get list of trip has tripId
+    let TripPlan = Parse.Object.extend('TripsPlan');
+    let tripPlan = new TripPlan();
+    tripPlan.id = this.getTripDetails.currentTrip.id;
+
+    let Sight = Parse.Object.extend('Sight');
+    let sightQueryTripId = new Parse.Query(Sight)
+    sightQueryTripId.equalTo('tripsPlanId', tripPlan)
+
+    let sightQueryVotedByUser = new Parse.Query(Sight);
+    sightQueryVotedByUser.equalTo('votes', user)
+
+    let mainQuery = Parse.Query.or(sightQueryTripId, sightQueryVotedByUser) // Find sights the user voted and are from this specific trip plan
+    let result = await mainQuery.find();
+    
+    for(let i=0; i < result.length; i++){
+      userVotes.push(result[i].get('XID')) // search the XID of the trips user voted and store in array
+    }
+    return userVotes;
   }
 }

--- a/GoTripApplication/src/app/services/vote.service.ts
+++ b/GoTripApplication/src/app/services/vote.service.ts
@@ -31,6 +31,9 @@ export class VoteService {
     sight.relation('votes').add(user); // Add the user ID to the relational data
 
     const point = new Parse.GeoPoint({latitude: place.geoPoints.lat, longitude: place.geoPoints.lon}) // Create geopoint in Parse format
+
+        
+    sight.increment('totalVotes'); // Add +1 to the totalVotes
     
     /*
     * Save the sight in Parse
@@ -61,6 +64,8 @@ export class VoteService {
     const user = new Parse.User(); // Create a user object with the loged user
     user.id = this.currentUser.userId;
     sight.relation('votes').remove(user); // Add the user ID to the relational data
+
+    sight.decrement('totalVotes'); // Add +1 to the totalVotes
 
     /* If there is only the vote from this user the sight should be completely removed */
 
@@ -107,5 +112,36 @@ export class VoteService {
     console.log('getting new user votes')
     console.log(userVotes)
     return userVotes;
+  }
+
+  /*
+  * Get list of XID and the total number of people who voted on it
+  */
+  async getTotalVotes(){
+
+    let listWithTotalVotes = [];
+
+    let Sight = Parse.Object.extend('Sight');
+    let sightVoted = new Parse.Query(Sight);
+
+    let TripPlan = Parse.Object.extend('TripsPlan');
+    let tripPlan = new TripPlan();
+    tripPlan.id = this.getTripDetails.currentTrip.id;
+
+    sightVoted.equalTo('tripsPlanId', tripPlan) // find all sights that have this tripId
+    let result = await sightVoted.find();
+
+    // Get the list of sights voted and count the number of votes
+
+    for(let i=0; i < result.length; i++){
+      let XID = result[i].get('XID');
+      let totalVotes = result[i].get('totalVotes');
+      totalVotes = totalVotes ? totalVotes : 0; //If it returns undefined it save zero votes
+
+      listWithTotalVotes.push({XID: XID, totalVotes: totalVotes});
+    }
+    return listWithTotalVotes // Return a array witht eh XID and total votes
+
+
   }
 }

--- a/GoTripApplication/src/app/services/vote.service.ts
+++ b/GoTripApplication/src/app/services/vote.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import * as Parse from 'parse';
+
+import { getTripDetails } from  './getTripDetails.service';
+import { currentUser } from './getCurrentUserData.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VoteService {
+
+  constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
+
+  addVote(place: any){
+    
+    let Sight = Parse.Object.extend('Sight');
+    let sight = new Sight();
+
+    let TripPlan = Parse.Object.extend('TripsPlan');
+    let tripPlan = new TripPlan();
+    tripPlan.id = this.getTripDetails.currentTrip.id; // Create a new object with the tripPlan ID
+
+    const user = new Parse.User(); // Create a user object with the loged user
+    user.id = this.currentUser.userId;
+    sight.relation('votes').add(user); // Add the user ID to the relational data
+
+    const point = new Parse.GeoPoint({latitude: place.geoPoints.lat, longitude: place.geoPoints.lon}) // Create geopoint in Parse format
+    
+    /*
+    * Save the sight in Parse
+    */
+    sight.save({
+      name: place.name,
+      tripsPlanId: tripPlan, // pointer
+      photoUrl: place.urlImage , 
+      XID: place.xid ,
+      description: place.description ,
+      geoPoint: point, // geopoint
+    }).then((res:any)=>{
+
+    }, (err:any)=>{
+      console.log(err)
+    })
+  }
+}

--- a/GoTripApplication/src/app/services/vote.service.ts
+++ b/GoTripApplication/src/app/services/vote.service.ts
@@ -3,11 +3,14 @@ import * as Parse from 'parse';
 
 import { getTripDetails } from  './getTripDetails.service';
 import { currentUser } from './getCurrentUserData.service';
+import { Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class VoteService {
+
+  updateUISightVoted = new Subject();
 
   constructor(private getTripDetails: getTripDetails, private currentUser: currentUser) { }
 
@@ -40,7 +43,7 @@ export class VoteService {
       description: place.description ,
       geoPoint: point, // geopoint
     }).then((res:any)=>{
-
+      this.updateUISightVoted.next(); // Update the UI
     }, (err:any)=>{
       console.log(err)
     })
@@ -66,7 +69,7 @@ export class VoteService {
     * Save the update in Parse
     */
     await sight.save().then((res:any)=>{
-
+      this.updateUISightVoted.next(); // Update the UI
     }, (err:any)=>{
       console.log(err)
     })

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.css
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.css
@@ -12,3 +12,18 @@
     font-size: 1.5em;
     font-weight: lighter;
 }
+
+.subheading {
+    color: #72768C;
+}
+
+.highlight{
+    color: #605DEC;
+    font-weight: bold;
+}
+
+.btn-primary{
+    background-color: #605DEC;
+    color: white;
+    border: 1px solid #605DEC;
+}

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
@@ -8,6 +8,13 @@
         <span class="heading">Expore {{city}}</span>
         <span class="subheading">Found <span class="highlight">({{count}})</span> nice places to visit</span>
     </div>
+    <!--Show Spinner while getting data-->
+    <div *ngIf="isLoading" class="row d-flex justify-content-center align-items-center" style="min-height:200px">
+        <div class="spinner-grow text-primary" role="status">
+            <span class="sr-only">Loading...</span>
+        </div>
+    </div>
+    <!--End of spinner-->
     <div class="row row-cols-3" style="min-height: 166px">
         <!--This should get ngFor-->
         <div class="col-4 px-1 mb-2" *ngFor="let sight of listOfSights">

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
@@ -11,7 +11,7 @@
         <!--This should get ngFor-->
         <div class="col-4 px-1 mb-2" *ngFor="let sight of listOfSights">
             <!-- Sights card component -->
-            <app-sight-card [isTheOwner]="isTheOwner" [sight]="sight"></app-sight-card>  
+            <app-sight-card [isTheOwner]="isTheOwner" [sight]="sight" [hasAcceptedInvitation]="hasAcceptedInvitation"></app-sight-card>  
         </div>
     </div>
 </div>

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.html
@@ -4,14 +4,20 @@
 
 -->
 <div class="col-12" style="min-height: 170px;">
-    <div class="row">
-        <span class="heading mb-4">Expore {{city}}</span>
+    <div class="row mb-4">
+        <span class="heading">Expore {{city}}</span>
+        <span class="subheading">Found <span class="highlight">({{count}})</span> nice places to visit</span>
     </div>
     <div class="row row-cols-3" style="min-height: 166px">
         <!--This should get ngFor-->
         <div class="col-4 px-1 mb-2" *ngFor="let sight of listOfSights">
             <!-- Sights card component -->
             <app-sight-card [isTheOwner]="isTheOwner" [sight]="sight" [hasAcceptedInvitation]="hasAcceptedInvitation"></app-sight-card>  
+        </div>
+    </div>
+    <div class="row">
+        <div class="col d-flex justify-content-center">
+            <button type="button" class="btn btn-primary my-3" (click)="nextPage()" >Next ({{total}} of {{count}})</button>
         </div>
     </div>
 </div>

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -49,9 +49,8 @@ export class AllSightsComponent implements OnInit {
   */
   getGeoLocation(){
     let method: string = 'geoname';
-    let name: string = this.city;
 
-    let url = `${this.urlBase}/${method}?lang=${this.lang}&name=${name}&country=${this.country}&apikey=${this.openTrip_API}`;
+    let url = `${this.urlBase}/${method}?lang=${this.lang}&name=${this.city}&country=${this.country}&apikey=${this.openTrip_API}`;
 
     this.http.get<{name: string, country: string, lat: number, lon:number, population: number, timezone: string, status: string}>(url)
     .subscribe(resp=>{
@@ -59,26 +58,40 @@ export class AllSightsComponent implements OnInit {
       if(resp.status == 'OK'){
         this.lat = resp.lat;
         this.lon = resp.lon;
+        this.getAmount() // get number of elements
         this.getSightList() // Starts the fucntion that will look for sights based on the lat and lon
-
+        console.log(resp.lat + '    '  + resp.lon)
       } else {}
      
      
     })
   
     }
-    
+  /*
+  * Find the amount of sights based on the place
+  */  
+  getAmount(){
+    let method: string = 'radius';
+    let format: string = 'count';
+
+    let url = `${this.urlBase}/${method}?lang=${this.lang}&format=${format}&name=${this.city}&radius=${this.radius}&limit=${this.limit}&offset=${this.offset}&lat=${this.lat}&lon=${this.lon}&rate=${this.rate}&apikey=${this.openTrip_API}`;
+
+    this.http.get<{count: number}>(url)
+    .subscribe(resp=>{
+      this.count = resp.count;
+      console.log('========>' +resp.count)
+    })
+  }
 
   /*
   * This functiin search for sights in the city based on lat and lon
   */
   getSightList(){
+    
     //`radius=1000&limit=${pageLength}&offset=${offset}&lon=${lon}&lat=${lat}&rate=2&format=count`
     let method: string = 'autosuggest';
-    let format: string = 'count';
-    let name: string = this.city;
 
-    let url = `${this.urlBase}/${method}?lang=${this.lang}&name=${name}&radius=${this.radius}&limit=${this.limit}&offset=${this.offset}&format=${format}&lat=${this.lat}&lon=${this.lon}&rate=${this.rate}&apikey=${this.openTrip_API}`;
+    let url = `${this.urlBase}/${method}?lang=${this.lang}&name=${this.city}&radius=${this.radius}&limit=${this.limit}&offset=${this.offset}&lat=${this.lat}&lon=${this.lon}&rate=${this.rate}&format=json&apikey=${this.openTrip_API}`;
 
     this.http.get<{dist:number, highlighted_name: string, kinds: string, name: string, point: {lon: number, lat: number}, rate: number, wikidate: string, xid: string}[]>(url)
     .subscribe(resp=>{
@@ -86,6 +99,7 @@ export class AllSightsComponent implements OnInit {
       * This is to handle the limits. OpenTripMap free account allows 10 request per second.
       * The bellow code will make the system wait 1 second if return an array with more then 5 sights
       */
+     console.log('======>' + resp[0])
       if(resp.length <= 5){
         for(let i = 0; i < resp.length; i++){
           this.getSightInfo(resp[i].xid);

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -14,6 +14,7 @@ export class AllSightsComponent implements OnInit {
   isTheOwner: boolean = false;
   listOfSights: {}[] = [];
   hasAcceptedInvitation: boolean = false;
+  isLoading: boolean = false;
 
   openTrip_API:any = this.env.OPENTRIP_API;
   urlBase:string = "https://api.opentripmap.com/0.1/en/places/";
@@ -98,7 +99,7 @@ export class AllSightsComponent implements OnInit {
   * This functiin search for sights in the city based on lat and lon
   */
   getSightList(){
-    
+    this.isLoading = true;
     //`radius=1000&limit=${pageLength}&offset=${offset}&lon=${lon}&lat=${lat}&rate=2&format=count`
     let method: string = 'autosuggest';
 
@@ -126,7 +127,8 @@ export class AllSightsComponent implements OnInit {
        }
       }, 2000); 
       }
-      this.calculateTotalItensShown()
+      this.calculateTotalItensShown();
+      this.isLoading = false;
       console.log(resp)
       
     })

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -200,6 +200,7 @@ export class AllSightsComponent implements OnInit, OnDestroy {
         totalVote: sightWithVotes.totalVotes
       }
       this.listOfSights = [...this.listOfSights, newSight ]
+      console.log(newSight)
       
     })
   }

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -47,15 +47,20 @@ export class AllSightsComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.getInitialdata()
-    this.getGeoLocation()
-    this.voteService.getUserVotes().then(res=> this.sightsVoted = res); // load votes from this user
+    this.sightsVoted = [];
+    console.log(this.sightsVoted);
+    this.getInitialdata();
+    this.getGeoLocation();
+    
+    
   }
 
   getInitialdata(){
     this.city = this.getTripDetails.currentTrip.destination;
     this.isTheOwner = this.getTripDetails.currentTrip.status.isTheOwner;
-    this.hasAcceptedInvitation = this.getTripDetails.currentTrip.status.hasAcceptedInvitation
+    this.hasAcceptedInvitation = this.getTripDetails.currentTrip.status.hasAcceptedInvitation;
+    this.voteService.getUserVotes().then(res=> this.sightsVoted = res) // load votes from this user
+    
   }
 
   /*
@@ -146,10 +151,17 @@ export class AllSightsComponent implements OnInit {
     this.http.get(url)
     .subscribe((resp:any)=>{
       
-      let findxid = this.sightsVoted.find(el=> el == resp.xid)
-
+      let voted:any = null;
+      console.log(this.sightsVoted)
+      this.sightsVoted.forEach((el:any)=>{
+        console.log(el.XID == resp.xid)
+        if(el.XID == resp.xid) voted = el
+      })
+      
+      
       let newSight: {} = {
         xid: resp.xid,
+        sightServerId: voted ? voted.sightId : null,
         name: resp.name,
         urlImage: resp.preview.source,
         description: resp.wikipedia_extracts.text,
@@ -157,7 +169,7 @@ export class AllSightsComponent implements OnInit {
           lon: resp.point.lon,
           lat: resp.point.lat
         },
-        userVoted: findxid ? true : false
+        userVoted: voted ? true : false
       }
       this.listOfSights = [...this.listOfSights, newSight ]
       console.log(this.listOfSights)

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -13,6 +13,7 @@ export class AllSightsComponent implements OnInit {
   city: string = '';
   isTheOwner: boolean = false;
   listOfSights: {}[] = [];
+  hasAcceptedInvitation: boolean = false;
 
   openTrip_API:any = this.env.OPENTRIP_API;
   urlBase:string = "https://api.opentripmap.com/0.1/en/places/";
@@ -40,6 +41,7 @@ export class AllSightsComponent implements OnInit {
   getInitialdata(){
     this.city = this.getTripDetails.currentTrip.destination;
     this.isTheOwner = this.getTripDetails.currentTrip.status.isTheOwner;
+    this.hasAcceptedInvitation = this.getTripDetails.currentTrip.status.hasAcceptedInvitation
   }
 
   /*

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -1,6 +1,5 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
 
 import { env } from 'src/app/env';
 import { getTripDetails } from '../../services/getTripDetails.service';
@@ -22,6 +21,7 @@ export class AllSightsComponent implements OnInit, OnDestroy {
   listOfSightVotes: {}[] = []; // List with all sights voted by any user invited for the trip
   listOfSightsAdded: {}[]=[];
   private updateUi: any;
+  private updateUiAfterAddSight: any;
 
   openTrip_API:any = this.env.OPENTRIP_API;
   urlBase:string = "https://api.opentripmap.com/0.1/en/places/";
@@ -67,6 +67,14 @@ export class AllSightsComponent implements OnInit, OnDestroy {
       this.listOfSights = [];
       this.getInitialdata();
       this.getSightList();
+    })
+
+    this.updateUiAfterAddSight = this.addSightService.updateUISightVoted.subscribe(()=>{
+      this.sightsVoted = [];
+      this.listOfSights = [];
+      this.getInitialdata();
+      this.getSightList();
+
     })
     
     
@@ -190,7 +198,7 @@ export class AllSightsComponent implements OnInit, OnDestroy {
       /*
       * Check if the sight was already added to the final trip
       */
-      let sightAdded: any = null
+      let sightAdded: any = {}
       this.listOfSightsAdded.forEach((el:any)=>{
         if(el.XID === resp.xid) sightAdded = el
       })
@@ -231,6 +239,7 @@ export class AllSightsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(){
     this.updateUi.unsubscribe()
+    this.updateUiAfterAddSight.unsubscribe()
   }
 
 }

--- a/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/all-sights.component.ts
@@ -21,13 +21,23 @@ export class AllSightsComponent implements OnInit {
   lon: number = 0;
   offset: number = 0; // offset from first object in the list
   limit: number = 3; // limit the number of results form the API
-  count: number = 0; // total objects count
   radius: number = 9000; // Area where the api will search for sights
   lang: string = 'en';
   country: string = 'DE';
   rate: number = 3; // How many starts it got.
 
+  count: number = 0; // total objects count
+  pageLength: number = 3 // number of cards per page
+  total: number = 0;
 
+  calculateTotalItensShown(){
+    if(this.count > 0){
+      this.total = this.offset + this.pageLength
+    } else {
+      this.total = 0
+    }
+    
+  }
   constructor(private getTripDetails: getTripDetails, private http: HttpClient, private env:env) { 
     
 
@@ -43,6 +53,7 @@ export class AllSightsComponent implements OnInit {
     this.isTheOwner = this.getTripDetails.currentTrip.status.isTheOwner;
     this.hasAcceptedInvitation = this.getTripDetails.currentTrip.status.hasAcceptedInvitation
   }
+
 
   /*
   * This function Fetch the lon and lat of the city
@@ -115,7 +126,7 @@ export class AllSightsComponent implements OnInit {
        }
       }, 2000); 
       }
-
+      this.calculateTotalItensShown()
       console.log(resp)
       
     })
@@ -145,6 +156,18 @@ export class AllSightsComponent implements OnInit {
       this.listOfSights = [...this.listOfSights, newSight ]
       console.log(this.listOfSights)
     })
+  }
+
+  /*
+  * Get data for the next page
+  */
+  nextPage(){
+    this.offset = this.offset + this.pageLength; // calculate the next
+    this.listOfSights = [] // Remove itens of previous search from the list
+    this.getSightList(); // Get next sights
+    this.calculateTotalItensShown() // calculate the total sight shown to update the button
+    console.log(this.offset)
+    console.log(this.total)
   }
 
 }

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.css
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.css
@@ -25,6 +25,10 @@
     transition: all 0.2s;
 }
 
+.voted {
+    color: #EB5757;
+}
+
 .like-counter{
     color: #605DEC;
     padding-left: 8px;

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -11,7 +11,7 @@
           </div>
           <!--Add button is only visible to trip Owners-->
           <div class="col-6 d-flex justify-content-end" *ngIf="isTheOwner">
-            <a class="btn btn-primary" (click)="add($event)">Add</a> 
+            <a class="btn btn-primary" (click)="add($event)" [attr.disabled]="!sight.sightServerId ? '' : null">Add</a> 
           </div>
       </div>
     </div>

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -7,7 +7,7 @@
       <div class="row">
           <div class="col-6 d-flex align-items-center" [attr.disabled]="!hasAcceptedInvitation ? '' : null">
             <i class="fa fa-heart fa-2x" [ngClass]="sight.userVoted == true ? 'voted' : 'like'" (click)="sight.userVoted ? removeVote($event) : vote($event)"></i>
-            <span class="like-counter">0</span>
+            <span class="like-counter">{{sight.totalVote}}</span>
           </div>
           <!--Add button is only visible to trip Owners-->
           <div class="col-6 d-flex justify-content-end" *ngIf="isTheOwner">

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -5,7 +5,7 @@
       <h5 class="card-title">{{sight.name | shortner:12}}</h5>
       <p class="card-text">{{sight.description | shortner:60}} </p>
       <div class="row">
-          <div class="col-6 d-flex align-items-center">
+          <div class="col-6 d-flex align-items-center" [attr.disabled]="!hasAcceptedInvitation ? '' : null">
             <i class="fa fa-heart fa-2x like" (click)="vote($event)"></i>
             <span class="like-counter">0</span>
           </div>

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -6,7 +6,7 @@
       <p class="card-text">{{sight.description | shortner:60}} </p>
       <div class="row">
           <div class="col-6 d-flex align-items-center" [attr.disabled]="!hasAcceptedInvitation ? '' : null">
-            <i class="fa fa-heart fa-2x" [ngClass]="sight.userVoted == true ? 'voted' : 'like'" (click)="vote($event)"></i>
+            <i class="fa fa-heart fa-2x" [ngClass]="sight.userVoted == true ? 'voted' : 'like'" (click)="sight.userVoted ? removeVote($event) : vote($event)"></i>
             <span class="like-counter">0</span>
           </div>
           <!--Add button is only visible to trip Owners-->

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -6,7 +6,7 @@
       <p class="card-text">{{sight.description | shortner:60}} </p>
       <div class="row">
           <div class="col-6 d-flex align-items-center" [attr.disabled]="!hasAcceptedInvitation ? '' : null">
-            <i class="fa fa-heart fa-2x like" (click)="vote($event)"></i>
+            <i class="fa fa-heart fa-2x" [ngClass]="sight.userVoted == true ? 'voted' : 'like'" (click)="vote($event)"></i>
             <span class="like-counter">0</span>
           </div>
           <!--Add button is only visible to trip Owners-->

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.html
@@ -10,8 +10,12 @@
             <span class="like-counter">{{sight.totalVote}}</span>
           </div>
           <!--Add button is only visible to trip Owners-->
-          <div class="col-6 d-flex justify-content-end" *ngIf="isTheOwner">
+          <div class="col-6 d-flex justify-content-end" *ngIf="isTheOwner && !sight.wasAdded">
             <a class="btn btn-primary" (click)="add($event)" [attr.disabled]="!sight.sightServerId ? '' : null">Add</a> 
+          </div>
+          <!--Remove button is only visible to trip Owners if the sight was added before-->
+          <div class="col-6 d-flex justify-content-end" *ngIf="isTheOwner && sight.wasAdded">
+            <a class="btn btn-primary" (click)="remove($event)">Remove</a> 
           </div>
       </div>
     </div>

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { MoreInfoService } from '../../../services/more-info.service';
+
 @Component({
   selector: 'app-sight-card',
   templateUrl: './sight-card.component.html',
@@ -9,16 +11,17 @@ import { ActivatedRoute, Router } from '@angular/router';
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
   @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number} } = {};
-  constructor(private route: Router, private activeRoute: ActivatedRoute) { }
+  
+  constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService) { }
 
   ngOnInit(): void {
   }
   /*
-  * Vote will open a new page with extra infromation about the sight
+  * the card will open a new page with extra infromation about the sight
   */
   openSightDetail(){
-    console.log('Open datailpage');
-    this.route.navigate(['../place'], {relativeTo: this.activeRoute})
+    this.moreInfoService.moreInfoAboutSight(this.sight) // save data on a service
+    this.route.navigate(['../place/', this.sight.xid], {relativeTo: this.activeRoute}) //open new page
     
   }
   /*
@@ -30,7 +33,7 @@ export class SightCardComponent implements OnInit {
     el.stopPropagation()
   }
   /*
-  * Vote will store the sight information in the Parse
+  * Add will store the sight information in the Parse
   */
   add(el:any){
     console.log('Add to map')

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { MoreInfoService } from '../../../services/more-info.service';
 import { VoteService } from '../../../services/vote.service';
+import { AddSightService } from '../../../services/add-sight.service';
 
 @Component({
   selector: 'app-sight-card',
@@ -12,9 +13,9 @@ import { VoteService } from '../../../services/vote.service';
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
   @Input() hasAcceptedInvitation: boolean = false;
-  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean, totalVote?:number } = {};
+  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean, totalVote?:number, sightServerId?:string } = {};
   
-  constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService) { }
+  constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService, private addSightService: AddSightService) { }
 
   ngOnInit(): void {
     console.log('OWNER==> '  +this.isTheOwner);
@@ -25,7 +26,7 @@ export class SightCardComponent implements OnInit {
   */
   openSightDetail(){
     this.moreInfoService.moreInfoAboutSight({...this.sight, hasAcceptedInvitation: this.hasAcceptedInvitation, isTheOwner: this.isTheOwner}) // save data on a service
-    this.route.navigate(['../place/', this.sight.xid], {relativeTo: this.activeRoute}) //open new page
+    this.route.navigate(['../place/'], {relativeTo: this.activeRoute}) //open new page
     
   }
   /*
@@ -42,10 +43,10 @@ export class SightCardComponent implements OnInit {
     console.log('remove vote')
   }
   /*
-  * Add will store the sight information in the Parse
+  * Add will go to the sight class and turn the item addedToTrip into true
   */
   add(el:any){
-    console.log('Add to map')
+    this.addSightService.addSight(this.sight)
     el.stopPropagation()
   }
 

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -12,7 +12,7 @@ import { VoteService } from '../../../services/vote.service';
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
   @Input() hasAcceptedInvitation: boolean = false;
-  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number} } = {};
+  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean } = {};
   
   constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService) { }
 
@@ -32,10 +32,9 @@ export class SightCardComponent implements OnInit {
   * Vote will store the user in the Parse
   */
   vote(el:any){
-    console.log('vote to visite')
-    console.log(el)
     el.stopPropagation()
-    this.voteService.addVote(this.sight)
+    this.voteService.addVote(this.sight);
+    this.voteService.getUserVotes();
   }
   /*
   * Add will store the sight information in the Parse

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { MoreInfoService } from '../../../services/more-info.service';
+import { VoteService } from '../../../services/vote.service';
 
 @Component({
   selector: 'app-sight-card',
@@ -13,7 +14,7 @@ export class SightCardComponent implements OnInit {
   @Input() hasAcceptedInvitation: boolean = false;
   @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number} } = {};
   
-  constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService) { }
+  constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService) { }
 
   ngOnInit(): void {
     console.log('OWNER==> '  +this.isTheOwner);
@@ -34,6 +35,7 @@ export class SightCardComponent implements OnInit {
     console.log('vote to visite')
     console.log(el)
     el.stopPropagation()
+    this.voteService.addVote(this.sight)
   }
   /*
   * Add will store the sight information in the Parse

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -12,7 +12,7 @@ import { VoteService } from '../../../services/vote.service';
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
   @Input() hasAcceptedInvitation: boolean = false;
-  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean } = {};
+  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean, totalVote?:number } = {};
   
   constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService) { }
 

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -10,17 +10,20 @@ import { MoreInfoService } from '../../../services/more-info.service';
 })
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
+  @Input() hasAcceptedInvitation: boolean = false;
   @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number} } = {};
   
   constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService) { }
 
   ngOnInit(): void {
+    console.log('OWNER==> '  +this.isTheOwner);
+    console.log('hasaccepet===> ' +this.hasAcceptedInvitation)
   }
   /*
   * the card will open a new page with extra infromation about the sight
   */
   openSightDetail(){
-    this.moreInfoService.moreInfoAboutSight(this.sight) // save data on a service
+    this.moreInfoService.moreInfoAboutSight({...this.sight, hasAcceptedInvitation: this.hasAcceptedInvitation, isTheOwner: this.isTheOwner}) // save data on a service
     this.route.navigate(['../place/', this.sight.xid], {relativeTo: this.activeRoute}) //open new page
     
   }

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -13,7 +13,7 @@ import { AddSightService } from '../../../services/add-sight.service';
 export class SightCardComponent implements OnInit {
   @Input() isTheOwner: boolean = false;
   @Input() hasAcceptedInvitation: boolean = false;
-  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean, totalVote?:number, sightServerId?:string } = {};
+  @Input() sight: {name?:string, xid?: string, urlImage?:string, description?:string, geoPoints?:{lon: number, lat: number}, userVoted?:boolean, totalVote?:number, sightServerId?:string, wasAdded?: boolean } = {};
   
   constructor(private route: Router, private activeRoute: ActivatedRoute, private moreInfoService: MoreInfoService, private voteService: VoteService, private addSightService: AddSightService) { }
 
@@ -47,6 +47,11 @@ export class SightCardComponent implements OnInit {
   */
   add(el:any){
     this.addSightService.addSight(this.sight)
+    el.stopPropagation()
+  }
+
+  remove(el:any){
+    this.addSightService.removeSight(this.sight)
     el.stopPropagation()
   }
 

--- a/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
+++ b/GoTripApplication/src/app/trip-details/all-sights/sight-card/sight-card.component.ts
@@ -36,6 +36,11 @@ export class SightCardComponent implements OnInit {
     this.voteService.addVote(this.sight);
     this.voteService.getUserVotes();
   }
+  removeVote(el:any){
+    el.stopPropagation()
+    this.voteService.removeVote(this.sight)
+    console.log('remove vote')
+  }
   /*
   * Add will store the sight information in the Parse
   */

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.css
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.css
@@ -1,0 +1,5 @@
+.btn-primary{
+    background-color: #605DEC;
+    border: 1px solid #605DEC;
+    color: white;
+}

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
@@ -2,14 +2,14 @@
     <app-breadcrumb></app-breadcrumb>
     <div class="row mb-4">
         <div class="col">
-            <img  [ngStyle]="{'background-image': 'url(http://localhost:4200/bg-invitation.jpg)', 'background-size': 'cover', 'background-position': 'center', 'min-height': '250px', 'min-width': '100%'}"  alt="..." >
+            <img  [ngStyle]="{'background-image': 'url(\''+ sight.urlImage + '\')', 'background-size': 'cover', 'background-position': 'center', 'min-height': '250px', 'min-width': '100%'}"  alt="..." >
         </div>
     </div>
     <div class="row">
         <div class="col-9">
-            <h4>Title of the place</h4>
+            <h4>{{sight.name}}</h4>
             <p>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+                {{sight.description}}
             </p>
         </div>
         <div class="col-3">

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
@@ -13,7 +13,7 @@
             </p>
         </div>
         <div class="col-3">
-            <button (click)="voteSight()" type="button" class="btn btn-primary my-3">Vote to Visit</button>
+            <button (click)="voteSight()" type="button" class="btn btn-primary my-3" [attr.disabled]="!sight.hasAcceptedInvitation ? '' : null">Vote to Visit</button>
         </div>
     </div>
 </div>

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
@@ -12,8 +12,12 @@
                 {{sight.description}}
             </p>
         </div>
-        <div class="col-3">
+        <div class="col-3" *ngIf="!sight.userVoted">
             <button (click)="voteSight()" type="button" class="btn btn-primary my-3" [attr.disabled]="!sight.hasAcceptedInvitation ? '' : null">Vote to Visit</button>
+        </div>
+        <!--Show this to users who voted-->
+        <div class="col-3" *ngIf="sight.userVoted">
+            <button (click)="unvoteSight()" type="button" class="btn btn-primary my-3" [attr.disabled]="!sight.hasAcceptedInvitation ? '' : null">Remove Vote</button>
         </div>
     </div>
 </div>

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <app-breadcrumb></app-breadcrumb>
+    <app-breadcrumb [origin]="'moreInfo'"></app-breadcrumb>
     <div class="row mb-4">
         <div class="col">
             <img  [ngStyle]="{'background-image': 'url(\''+ sight.urlImage + '\')', 'background-size': 'cover', 'background-position': 'center', 'min-height': '250px', 'min-width': '100%'}"  alt="..." >
@@ -13,7 +13,7 @@
             </p>
         </div>
         <div class="col-3">
-            <button type="button" class="btn btn-primary my-3">Vote to Visit</button>
+            <button (click)="voteSight()" type="button" class="btn btn-primary my-3">Vote to Visit</button>
         </div>
     </div>
 </div>

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
@@ -19,6 +19,10 @@ export class SightDetailComponent implements OnInit, OnDestroy{
     
   }
 
+  voteSight(){
+    console.log('Vite to visit this sight')
+  }
+
   ngOnDestroy(){
     this.moreInfoService.cleanMoreInfoAboutSight()
   }

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { MoreInfoService } from '../../services/more-info.service';
+import { VoteService } from '../../services/vote.service';
 
 @Component({
   selector: 'app-sight-detail',
@@ -8,23 +10,37 @@ import { MoreInfoService } from '../../services/more-info.service';
   styleUrls: ['./sight-detail.component.css']
 })
 export class SightDetailComponent implements OnInit, OnDestroy{
-  sight: any = {}
+  sight: any = {};
+  private updateUi: any;
 
-  constructor(private  moreInfoService: MoreInfoService) {
+  constructor(private  moreInfoService: MoreInfoService, private voteService: VoteService, private router: Router, private activeRoute: ActivatedRoute) {
     this.sight = this.moreInfoService.knowInfoAboutThisSight;
-    console.log(this.sight)
    }
 
   ngOnInit(): void {
+
+    /*
+    * This will run after the user click on the vote/remove vote button
+    */
+    this.updateUi = this.voteService.updateUISightVoted.subscribe(()=>{
+      console.log('updating...')
+      this.router.navigate(['../place'],{relativeTo:this.activeRoute})
+    })
     
   }
 
   voteSight(){
-    console.log('Vite to visit this sight')
+    this.voteService.addVote(this.sight)
+  }
+
+  unvoteSight(){
+    this.voteService.removeVote(this.sight)
   }
 
   ngOnDestroy(){
-    this.moreInfoService.cleanMoreInfoAboutSight()
+    this.moreInfoService.cleanMoreInfoAboutSight();
+    this.updateUi.unsubscribe();
   }
+
 
 }

--- a/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
+++ b/GoTripApplication/src/app/trip-details/sight-detail/sight-detail.component.ts
@@ -1,15 +1,26 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+
+import { MoreInfoService } from '../../services/more-info.service';
 
 @Component({
   selector: 'app-sight-detail',
   templateUrl: './sight-detail.component.html',
   styleUrls: ['./sight-detail.component.css']
 })
-export class SightDetailComponent implements OnInit {
+export class SightDetailComponent implements OnInit, OnDestroy{
+  sight: any = {}
 
-  constructor() { }
+  constructor(private  moreInfoService: MoreInfoService) {
+    this.sight = this.moreInfoService.knowInfoAboutThisSight;
+    console.log(this.sight)
+   }
 
   ngOnInit(): void {
+    
+  }
+
+  ngOnDestroy(){
+    this.moreInfoService.cleanMoreInfoAboutSight()
   }
 
 }


### PR DESCRIPTION
In this one, the user, trip owner or invited friends, can choose the sights. Once the sight is voted it is stored on Parse. 

It also shows the number of votes next to the heart icon.

The trip owner can add or remove the voted sights.

If the user clicks on the sight cards, a new page will be opened showing an extra page with more details about the sight. The user can also vote there using a button. 

There is also a pagination feature at the bottom to load more sights. It is loading only 3 because we are using the free API, want avoid to consume too much. Once we deliver the project I can increase it to show 9 items. 
